### PR TITLE
openvoxdb_version fact: Fix binary name

### DIFF
--- a/lib/facter/openvoxdb_version.rb
+++ b/lib/facter/openvoxdb_version.rb
@@ -1,5 +1,5 @@
 Facter.add(:openvoxdb_version) do
-  confine { Facter::Util::Resolution.which('openvoxdb') }
+  confine { Facter::Util::Resolution.which('puppetdb') }
 
   setcode do
     output = Facter::Core::Execution.execute('puppetdb --version')

--- a/spec/unit/facter/puppetdb_version_spec.rb
+++ b/spec/unit/facter/puppetdb_version_spec.rb
@@ -7,7 +7,7 @@ describe 'openvoxdb_version' do
 
   context 'when puppetdb is available' do
     before do
-      allow(Facter::Util::Resolution).to receive(:which).with('openvoxdb').and_return('/usr/bin/puppetdb')
+      allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return('/usr/bin/puppetdb')
     end
 
     context 'on a default system' do
@@ -29,7 +29,7 @@ describe 'openvoxdb_version' do
 
   context 'when puppetdb is not available' do
     before do
-      allow(Facter::Util::Resolution).to receive(:which).with('openvoxdb').and_return(nil)
+      allow(Facter::Util::Resolution).to receive(:which).with('puppetdb').and_return(nil)
     end
 
     it 'returns nil' do


### PR DESCRIPTION
During the module rename from puppetlabs/puppetdb -> puppet/openvoxdb, this file got changed. But that's not correct, our openvoxdb package contains the puppetdb binary. This wasn't renamed:

```
root@puppet ~ # puppetdb --version
puppetdb version: 8.13.0
root@puppet ~ # dnf info openvoxdb
Installed Packages
Name         : openvoxdb
Version      : 8.13.0
Release      : 1.el9
Architecture : noarch
Size         : 67 M
Source       : openvoxdb-8.13.0-1.el9.src.rpm
Repository   : @System
From repo    : openvox8
Summary      : Vox Pupuli puppetdb
URL          : http://github.com/openvoxproject
License      : Apache-2.0
Description  : Vox Pupuli puppetdb
             : Contains: OpenVox-integrated catalog and fact storage (org.openvoxproject/puppetdb
             : 8.13.0,org.bouncycastle/bcpkix-jdk18on 1.84,org.clojure/clojure
             : 1.12.4,org.openvoxproject/puppetdb 8.13.0)

root@puppet ~ #
```

Fixes 8c91e363

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
