### PR TITLE
feat: add puppetdb_version parameter also to openvoxdb::server

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1388,6 +1388,7 @@ The following parameters are available in the `openvoxdb::server` class:
 * [`conn_max_age`](#-openvoxdb--server--conn_max_age)
 * [`conn_lifetime`](#-openvoxdb--server--conn_lifetime)
 * [`puppetdb_package`](#-openvoxdb--server--puppetdb_package)
+* [`puppetdb_version`](#-openvoxdb--server--puppetdb_version)
 * [`puppetdb_service`](#-openvoxdb--server--puppetdb_service)
 * [`puppetdb_service_status`](#-openvoxdb--server--puppetdb_service_status)
 * [`puppetdb_user`](#-openvoxdb--server--puppetdb_user)
@@ -1700,6 +1701,14 @@ Data type: `Any`
 The PuppetDB package name in the package manager. Defaults to `present`.
 
 Default value: `$openvoxdb::params::puppetdb_package`
+
+##### <a name="-openvoxdb--server--puppetdb_version"></a>`puppetdb_version`
+
+Data type: `String[1]`
+
+Version of the PuppetDB package to install. Defaults to `present`
+
+Default value: `$openvoxdb::params::puppetdb_version`
 
 ##### <a name="-openvoxdb--server--puppetdb_service"></a>`puppetdb_service`
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -119,6 +119,9 @@
 # @param puppetdb_package
 #   The PuppetDB package name in the package manager. Defaults to `present`.
 #
+# @param puppetdb_version
+#   Version of the PuppetDB package to install. Defaults to `present`
+#
 # @param puppetdb_service
 #   The name of the PuppetDB service. Defaults to `puppetdb`.
 #
@@ -350,6 +353,7 @@ class openvoxdb::server (
   $conn_max_age                            = $openvoxdb::params::conn_max_age,
   $conn_lifetime                           = $openvoxdb::params::conn_lifetime,
   $puppetdb_package                        = $openvoxdb::params::puppetdb_package,
+  String[1] $puppetdb_version              = $openvoxdb::params::puppetdb_version,
   $puppetdb_service                        = $openvoxdb::params::puppetdb_service,
   $puppetdb_service_status                 = $openvoxdb::params::puppetdb_service_status,
   $puppetdb_user                           = $openvoxdb::params::puppetdb_user,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Since the removal of `puppetdb::globals` we need to be able to pass a package version parameter.

An equivalent parameter has been added to `openvoxdb` via #42, but we also need to add it to `openvoxdb::server` as it could be used directly.