### PR TITLE
remove workarounds that are no longer necessary

### DIFF
--- a/data/os/RedHat/10.yaml
+++ b/data/os/RedHat/10.yaml
@@ -1,3 +1,2 @@
 ---
-# As of v10.6.1, puppetlabs/postgresql does not have EL10 support/data
 openvoxdb::postgres_version: '16'

--- a/spec/unit/classes/init_spec.rb
+++ b/spec/unit/classes/init_spec.rb
@@ -19,19 +19,10 @@ describe 'openvoxdb', type: :class do
 
       describe 'without managed postgresql' do
         let :pre_condition do
-          if facts.dig(:os, 'family') == 'RedHat' && facts.dig(:os, 'release', 'major') == '10'
-            <<-HEREDOC
-            class { 'postgresql::globals':
-              version => '16',
-            }
-            -> class { 'postgresql::server': }
-            HEREDOC
-          else
-            <<-HEREDOC
-            class { 'postgresql::server':
-            }
-            HEREDOC
-          end
+          <<-HEREDOC
+          class { 'postgresql::server':
+          }
+          HEREDOC
         end
 
         let :params do


### PR DESCRIPTION
- v10.6.2 of puppetlabs-postgresql has support for EL10