### PR TITLE
Actually use puppetdb_version set as class parameters

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1143,6 +1143,7 @@ The following parameters are available in the `openvoxdb::master::config` class:
 * [`puppet_conf`](#-openvoxdb--master--config--puppet_conf)
 * [`masterless`](#-openvoxdb--master--config--masterless)
 * [`terminus_package`](#-openvoxdb--master--config--terminus_package)
+* [`terminus_package_version`](#-openvoxdb--master--config--terminus_package_version)
 * [`puppet_service_name`](#-openvoxdb--master--config--puppet_service_name)
 * [`puppetdb_startup_timeout`](#-openvoxdb--master--config--puppetdb_startup_timeout)
 * [`test_url`](#-openvoxdb--master--config--test_url)
@@ -1310,6 +1311,14 @@ Data type: `Any`
 Name of the package to use that represents the PuppetDB terminus code.
 
 Default value: `$openvoxdb::params::terminus_package`
+
+##### <a name="-openvoxdb--master--config--terminus_package_version"></a>`terminus_package_version`
+
+Data type: `Any`
+
+Version of the OpenVoxDB terminus package to install. Defaults to `present`
+
+Default value: `$openvoxdb::params::terminus_package_version`
 
 ##### <a name="-openvoxdb--master--config--puppet_service_name"></a>`puppet_service_name`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -474,6 +474,7 @@ class openvoxdb (
     conn_max_age                      => $conn_max_age,
     conn_lifetime                     => $conn_lifetime,
     puppetdb_package                  => $puppetdb_package,
+    puppetdb_version                  => $puppetdb_version,
     puppetdb_service                  => $puppetdb_service,
     puppetdb_service_status           => $puppetdb_service_status,
     confdir                           => $confdir,

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -68,6 +68,9 @@
 # @param terminus_package
 #   Name of the package to use that represents the PuppetDB terminus code.
 #
+# @param terminus_package_version
+#   Version of the OpenVoxDB terminus package to install. Defaults to `present`
+#
 # @param puppet_service_name
 #   Name of the service that represents Puppet. You can change this to `apache2` or
 #   `httpd` depending on your operating system, if you plan on having Puppet run
@@ -113,13 +116,14 @@ class openvoxdb::master::config (
   $puppet_confdir              = $openvoxdb::params::puppet_confdir,
   $puppet_conf                 = $openvoxdb::params::puppet_conf,
   $terminus_package            = $openvoxdb::params::terminus_package,
+  $terminus_package_version    = $openvoxdb::params::terminus_package_version,
   $puppet_service_name         = $openvoxdb::params::puppet_service_name,
   $puppetdb_startup_timeout    = $openvoxdb::params::puppetdb_startup_timeout,
   $test_url                    = $openvoxdb::params::test_url,
   $restart_puppet              = true,
 ) inherits openvoxdb::params {
   package { $terminus_package:
-    ensure => $openvoxdb::params::puppetdb_version,
+    ensure => $terminus_package_version,
   }
 
   if ($strict_validation) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -83,48 +83,52 @@ class openvoxdb::params {
 
   case fact('os.family') {
     'Debian': {
-      $puppetdb_package    = 'openvoxdb'
-      $terminus_package    = 'openvoxdb-termini'
-      $etcdir              = '/etc/puppetlabs/puppetdb'
-      $puppet_confdir      = '/etc/puppetlabs/puppet'
-      $puppet_service_name = 'puppetserver'
-      $vardir              = '/opt/puppetlabs/server/data/puppetdb'
-      $puppetdb_user       = 'puppetdb'
-      $puppetdb_group      = 'puppetdb'
-      $puppetdb_initconf   = '/etc/default/puppetdb'
+      $puppetdb_package         = 'openvoxdb'
+      $terminus_package         = 'openvoxdb-termini'
+      $terminus_package_version = 'present'
+      $etcdir                   = '/etc/puppetlabs/puppetdb'
+      $puppet_confdir           = '/etc/puppetlabs/puppet'
+      $puppet_service_name      = 'puppetserver'
+      $vardir                   = '/opt/puppetlabs/server/data/puppetdb'
+      $puppetdb_user            = 'puppetdb'
+      $puppetdb_group           = 'puppetdb'
+      $puppetdb_initconf        = '/etc/default/puppetdb'
     }
     'FreeBSD': {
-      $puppetdb_package    = "openvoxdb${openvoxdb::params::puppetdb_major_version}"
-      $terminus_package    = "openvoxdb-terminus${openvoxdb::params::puppetdb_major_version}"
-      $etcdir              = '/usr/local/etc/puppetdb'
-      $puppet_confdir      = '/usr/local/etc/puppet'
-      $puppet_service_name = 'puppetserver'
-      $vardir              = '/var/db/puppetdb'
-      $puppetdb_user       = '_puppetdb'
-      $puppetdb_group      = '_puppetdb'
-      $puppetdb_initconf   = undef
+      $puppetdb_package         = "openvoxdb${openvoxdb::params::puppetdb_major_version}"
+      $terminus_package         = "openvoxdb-terminus${openvoxdb::params::puppetdb_major_version}"
+      $terminus_package_version = 'present'
+      $etcdir                   = '/usr/local/etc/puppetdb'
+      $puppet_confdir           = '/usr/local/etc/puppet'
+      $puppet_service_name      = 'puppetserver'
+      $vardir                   = '/var/db/puppetdb'
+      $puppetdb_user            = '_puppetdb'
+      $puppetdb_group           = '_puppetdb'
+      $puppetdb_initconf        = undef
     }
     'OpenBSD': {
-      $puppetdb_package    = 'openvoxdb'
-      $terminus_package    = 'openvoxdb-termini'
-      $etcdir              = '/etc/puppetlabs/puppetdb'
-      $puppet_confdir      = '/etc/puppetlabs/puppet'
-      $puppet_service_name = undef
-      $vardir              = '/opt/puppetlabs/server/data/puppetdb'
-      $puppetdb_user       = '_puppetdb'
-      $puppetdb_group      = '_puppetdb'
-      $puppetdb_initconf   = undef
+      $puppetdb_package         = 'openvoxdb'
+      $terminus_package         = 'openvoxdb-termini'
+      $terminus_package_version = 'present'
+      $etcdir                   = '/etc/puppetlabs/puppetdb'
+      $puppet_confdir           = '/etc/puppetlabs/puppet'
+      $puppet_service_name      = undef
+      $vardir                   = '/opt/puppetlabs/server/data/puppetdb'
+      $puppetdb_user            = '_puppetdb'
+      $puppetdb_group           = '_puppetdb'
+      $puppetdb_initconf        = undef
     }
     'RedHat', 'Suse': {
-      $puppetdb_package    = 'openvoxdb'
-      $terminus_package    = 'openvoxdb-termini'
-      $etcdir              = '/etc/puppetlabs/puppetdb'
-      $puppet_confdir      = '/etc/puppetlabs/puppet'
-      $puppet_service_name = 'puppetserver'
-      $vardir              = '/opt/puppetlabs/server/data/puppetdb'
-      $puppetdb_user       = 'puppetdb'
-      $puppetdb_group      = 'puppetdb'
-      $puppetdb_initconf   = '/etc/sysconfig/puppetdb'
+      $puppetdb_package         = 'openvoxdb'
+      $terminus_package         = 'openvoxdb-termini'
+      $terminus_package_version = 'present'
+      $etcdir                   = '/etc/puppetlabs/puppetdb'
+      $puppet_confdir           = '/etc/puppetlabs/puppet'
+      $puppet_service_name      = 'puppetserver'
+      $vardir                   = '/opt/puppetlabs/server/data/puppetdb'
+      $puppetdb_user            = 'puppetdb'
+      $puppetdb_group           = 'puppetdb'
+      $puppetdb_initconf        = '/etc/sysconfig/puppetdb'
     }
     default: {
       fail("The fact 'os.family' is set to ${fact('os.family')} which is not supported by the puppetdb module.")

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -430,7 +430,7 @@ class openvoxdb::server (
   }
 
   package { $puppetdb_package:
-    ensure => $openvoxdb::params::puppetdb_version,
+    ensure => $puppetdb_version,
     notify => Service[$puppetdb_service],
   }
 


### PR DESCRIPTION
#### Pull Request (PR) description

Properly solve the issue reported through #46 (#47 was closed, not merged).

#### This Pull Request (PR) fixes the following issues

Fixes #46 (even though that is already closed)

#### Sidenote

I have not changed the parameter defaults for `openvoxdb::server`, they still all fall back to `openvoxdb::params`. Though this paradigm is open for Puppet's automatic parameter lookup, which was broken at least for the openvoxdb package resource, by _also_ using the value from `params.pp`.